### PR TITLE
Itemテーブルからdelivery_idカラム削除

### DIFF
--- a/db/migrate/20190112104333_remove_delivery_id_from_items.rb
+++ b/db/migrate/20190112104333_remove_delivery_id_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveDeliveryIdFromItems < ActiveRecord::Migration[5.0]
+  def change
+    remove_reference :items, :delivery, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190111074949) do
+ActiveRecord::Schema.define(version: 20190112104333) do
 
   create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name"
@@ -38,8 +38,8 @@ ActiveRecord::Schema.define(version: 20190111074949) do
   end
 
   create_table "images", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.text     "image",      limit: 65535, null: false
-    t.integer  "item_id",                  null: false
+    t.text     "image",      limit: 65535
+    t.integer  "item_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["item_id"], name: "index_images_on_item_id", using: :btree
@@ -56,13 +56,11 @@ ActiveRecord::Schema.define(version: 20190111074949) do
     t.datetime "updated_at"
     t.integer  "brand_id"
     t.integer  "category_id"
-    t.integer  "delivery_id"
     t.integer  "buyer_id"
     t.integer  "seller_id"
     t.index ["brand_id"], name: "index_items_on_brand_id", using: :btree
     t.index ["buyer_id"], name: "index_items_on_buyer_id", using: :btree
     t.index ["category_id"], name: "index_items_on_category_id", using: :btree
-    t.index ["delivery_id"], name: "index_items_on_delivery_id", using: :btree
     t.index ["seller_id"], name: "index_items_on_seller_id", using: :btree
   end
 
@@ -85,7 +83,6 @@ ActiveRecord::Schema.define(version: 20190111074949) do
   add_foreign_key "images", "items"
   add_foreign_key "items", "brands"
   add_foreign_key "items", "categories"
-  add_foreign_key "items", "deliveries"
   add_foreign_key "items", "users", column: "buyer_id"
   add_foreign_key "items", "users", column: "seller_id"
 end


### PR DESCRIPTION
#Why
Deliveryテーブルでitem_idをとっているので
不要と判断したため